### PR TITLE
refs platform/1656: refactor bucket creation with versionig and backup lifecycle , change…

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,16 +33,17 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allow\_force\_destroy | Allows full cleanup of resources by disabling any deletion safe guards | `bool` | `false` | no |
 | certmanager\_email | Email used to retrieve SSL certificates from Let's Encrypt | `string` | n/a | yes |
 | domain | Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at gitlab.mydomain.com) | `string` | `""` | no |
 | gcp\_existing\_db\_secret\_name | Setup the GCP secret name where to retrieve the password value that will be used for postgres DB. In case an empty string is passed,a random value will be filled in a default gcp secret named gitlab-db-password | `string` | `""` | no |
 | gcp\_existing\_omniauth\_secret\_name | Only if Omniauth is enabled. Setup the GCP secret name where to retrieve the configuration that will be used for Omniauth Configuration. | `string` | `""` | no |
 | gcp\_existing\_smtp\_secret\_name | Only if STMP is enabled. Setup the GCP secret name where to retrieve the password value that will be used for Smtp Account. | `string` | `""` | no |
+| gcs\_bucket\_age\_backup\_sc\_change | When the backup lifecycle is enabled, set the number of days after the storage class changes | `number` | `30` | no |
 | gcs\_bucket\_allow\_force\_destroy | Allows full cleanup of buckets by disabling any deletion safe guards | `bool` | `false` | no |
 | gcs\_bucket\_backup\_duration | When the backup lifecycle is enabled, set the number of days after which the backup files are deleted | `number` | `120` | no |
-| gcs\_bucket\_backup\_sc\_change | When the backup lifecycle is enabled, set the number of days after the storage class changes to coldline | `number` | `30` | no |
+| gcs\_bucket\_enable\_backup\_lifecycle\_rule | Enable lifecycle rule for backup bucket | `bool` | `false` | no |
 | gcs\_bucket\_storage\_class | Bucket storage class. Supported values include: STANDARD, MULTI\_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE | `string` | `"STANDARD"` | no |
+| gcs\_bucket\_target\_storage\_class | The target Storage Class of objects affected by this Lifecycle Rule. Supported values include: STANDARD, MULTI\_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE. | `string` | `"COLDLINE"` | no |
 | gcs\_bucket\_versioning | Setup Object Storage versioning for all Bucket created. | `bool` | `true` | no |
 | gitlab\_address\_name | Name of the address to use for GitLab ingress | `string` | `""` | no |
 | gitlab\_backup\_extra\_args | Add a string of extra arguments for the gitlab backup-utility. | `string` | `""` | no |
@@ -122,6 +123,7 @@ Then perform the following commands on the root folder:
 | gitlab\_address | IP address where you can connect to your GitLab instance |
 | gitlab\_url | URL where you can access your GitLab instance |
 | root\_password\_instructions | Instructions for getting the root user's password for initial setup |
+| service\_account\_id | The id of the default service account |
 
  <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/README.md
+++ b/README.md
@@ -33,14 +33,17 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| allow\_force\_destroy | Allows full cleanup of resources by disabling any deletion safe guards | `bool` | `false` | no |
 | certmanager\_email | Email used to retrieve SSL certificates from Let's Encrypt | `string` | n/a | yes |
 | domain | Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at gitlab.mydomain.com) | `string` | `""` | no |
 | gcp\_existing\_db\_secret\_name | Setup the GCP secret name where to retrieve the password value that will be used for postgres DB. In case an empty string is passed,a random value will be filled in a default gcp secret named gitlab-db-password | `string` | `""` | no |
 | gcp\_existing\_omniauth\_secret\_name | Only if Omniauth is enabled. Setup the GCP secret name where to retrieve the configuration that will be used for Omniauth Configuration. | `string` | `""` | no |
 | gcp\_existing\_smtp\_secret\_name | Only if STMP is enabled. Setup the GCP secret name where to retrieve the password value that will be used for Smtp Account. | `string` | `""` | no |
+| gcs\_bucket\_allow\_force\_destroy | Allows full cleanup of buckets by disabling any deletion safe guards | `bool` | `false` | no |
+| gcs\_bucket\_backup\_duration | When the backup lifecycle is enabled, set the number of days after which the backup files are deleted | `number` | `120` | no |
+| gcs\_bucket\_backup\_sc\_change | When the backup lifecycle is enabled, set the number of days after the storage class changes to coldline | `number` | `14` | no |
 | gcs\_bucket\_random\_suffix | Sets random suffix at the end of the bucket name. | `bool` | `false` | no |
 | gcs\_bucket\_storage\_class | Bucket storage class. Supported values include: STANDARD, MULTI\_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE | `string` | `"STANDARD"` | no |
+| gcs\_bucket\_versioning | Setup Object Storage versioning for all Bucket created. | `bool` | `false` | no |
 | gitlab\_address\_name | Name of the address to use for GitLab ingress | `string` | `""` | no |
 | gitlab\_backup\_extra\_args | Add a string of extra arguments for the gitlab backup-utility. | `string` | `""` | no |
 | gitlab\_backup\_pv\_size | Set the size of the additional storage for Backup TAR Creation | `number` | `100` | no |
@@ -87,8 +90,8 @@ Then perform the following commands on the root folder:
 | gke\_min\_node\_count | Define the minimum number of nodes of the autoscaling cluster. Default 1 | `number` | `1` | no |
 | gke\_nodes\_subnet\_cidr | Cidr range to use for gitlab GKE nodes subnet | `string` | `"10.10.0.0/16"` | no |
 | gke\_pods\_subnet\_cidr | Cidr range to use for gitlab GKE pods subnet | `string` | `"10.30.0.0/16"` | no |
-| gke\_sc\_gitlab\_backup\_disk | Storage class for Perstistent Volume used for extra space in Backup Cron Job . Default pd-sdd. | `string` | `"pd-ssd"` | no |
-| gke\_sc\_gitlab\_restore\_disk | Storage class for Perstistent Volume used for extra space in Backup Restore Job. Default pd-sdd. | `string` | `"pd-ssd"` | no |
+| gke\_sc\_gitlab\_backup\_disk | Storage class for Perstistent Volume used for extra space in Backup Cron Job . Default pd-sdd. | `string` | `"standard"` | no |
+| gke\_sc\_gitlab\_restore\_disk | Storage class for Perstistent Volume used for extra space in Backup Restore Job. Default pd-sdd. | `string` | `"standard"` | no |
 | gke\_services\_subnet\_cidr | Cidr range to use for gitlab GKE services subnet | `string` | `"10.20.0.0/16"` | no |
 | gke\_storage\_class | Default storage class for GKE Cluster. Default pd-sdd. | `string` | `"pd-ssd"` | no |
 | gke\_version | Version of GKE to use for the GitLab cluster | `string` | `"latest"` | no |

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Then perform the following commands on the root folder:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| allow\_force\_destroy | Allows full cleanup of resources by disabling any deletion safe guards | `bool` | `false` | no |
 | certmanager\_email | Email used to retrieve SSL certificates from Let's Encrypt | `string` | n/a | yes |
 | domain | Domain for hosting gitlab functionality (ie mydomain.com would access gitlab at gitlab.mydomain.com) | `string` | `""` | no |
 | gcp\_existing\_db\_secret\_name | Setup the GCP secret name where to retrieve the password value that will be used for postgres DB. In case an empty string is passed,a random value will be filled in a default gcp secret named gitlab-db-password | `string` | `""` | no |
@@ -40,10 +41,9 @@ Then perform the following commands on the root folder:
 | gcp\_existing\_smtp\_secret\_name | Only if STMP is enabled. Setup the GCP secret name where to retrieve the password value that will be used for Smtp Account. | `string` | `""` | no |
 | gcs\_bucket\_allow\_force\_destroy | Allows full cleanup of buckets by disabling any deletion safe guards | `bool` | `false` | no |
 | gcs\_bucket\_backup\_duration | When the backup lifecycle is enabled, set the number of days after which the backup files are deleted | `number` | `120` | no |
-| gcs\_bucket\_backup\_sc\_change | When the backup lifecycle is enabled, set the number of days after the storage class changes to coldline | `number` | `14` | no |
-| gcs\_bucket\_random\_suffix | Sets random suffix at the end of the bucket name. | `bool` | `false` | no |
+| gcs\_bucket\_backup\_sc\_change | When the backup lifecycle is enabled, set the number of days after the storage class changes to coldline | `number` | `30` | no |
 | gcs\_bucket\_storage\_class | Bucket storage class. Supported values include: STANDARD, MULTI\_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE | `string` | `"STANDARD"` | no |
-| gcs\_bucket\_versioning | Setup Object Storage versioning for all Bucket created. | `bool` | `false` | no |
+| gcs\_bucket\_versioning | Setup Object Storage versioning for all Bucket created. | `bool` | `true` | no |
 | gitlab\_address\_name | Name of the address to use for GitLab ingress | `string` | `""` | no |
 | gitlab\_backup\_extra\_args | Add a string of extra arguments for the gitlab backup-utility. | `string` | `""` | no |
 | gitlab\_backup\_pv\_size | Set the size of the additional storage for Backup TAR Creation | `number` | `100` | no |

--- a/outputs.tf
+++ b/outputs.tf
@@ -45,3 +45,8 @@ output "root_password_instructions" {
 
   description = "Instructions for getting the root user's password for initial setup"
 }
+
+output "service_account_id" {
+  value       = google_service_account.gitlab_gcs.account_id
+  description = "The id of the default service account"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -137,10 +137,22 @@ variable "gcs_bucket_versioning" {
   default     = true
 }
 
-variable "gcs_bucket_backup_sc_change" {
+variable "gcs_bucket_enable_backup_lifecycle_rule" {
+  type        = bool
+  description = "Enable lifecycle rule for backup bucket"
+  default     = false
+}
+
+variable "gcs_bucket_age_backup_sc_change" {
   type        = number
-  description = "When the backup lifecycle is enabled, set the number of days after the storage class changes to coldline"
+  description = "When the backup lifecycle is enabled, set the number of days after the storage class changes"
   default     = 30
+}
+
+variable "gcs_bucket_target_storage_class" {
+  type        = string
+  description = "The target Storage Class of objects affected by this Lifecycle Rule. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE."
+  default     = "COLDLINE"
 }
 
 variable "gcs_bucket_backup_duration" {

--- a/variables.tf
+++ b/variables.tf
@@ -29,12 +29,6 @@ variable "region" {
   default     = "europe-west1"
 }
 
-variable "allow_force_destroy" {
-  type        = bool
-  default     = false
-  description = "Allows full cleanup of resources by disabling any deletion safe guards"
-}
-
 variable "gitlab_address_name" {
   type        = string
   description = "Name of the address to use for GitLab ingress"
@@ -131,10 +125,34 @@ variable "gcs_bucket_random_suffix" {
   default     = false
 }
 
+variable "gcs_bucket_allow_force_destroy" {
+  type        = bool
+  default     = false
+  description = "Allows full cleanup of buckets by disabling any deletion safe guards"
+}
+
 variable "gcs_bucket_storage_class" {
   type        = string
   description = "Bucket storage class. Supported values include: STANDARD, MULTI_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE "
   default     = "STANDARD"
+}
+
+variable "gcs_bucket_versioning" {
+  type        = bool
+  description = "Setup Object Storage versioning for all Bucket created."
+  default     = false
+}
+
+variable "gcs_bucket_backup_sc_change" {
+  type        = number
+  description = "When the backup lifecycle is enabled, set the number of days after the storage class changes to coldline"
+  default     = 14
+}
+
+variable "gcs_bucket_backup_duration" {
+  type        = number
+  description = "When the backup lifecycle is enabled, set the number of days after which the backup files are deleted"
+  default     = 120
 }
 
 ##################
@@ -240,13 +258,13 @@ variable "gke_istio_auth" {
 variable "gke_sc_gitlab_backup_disk" {
   type        = string
   description = "Storage class for Perstistent Volume used for extra space in Backup Cron Job . Default pd-sdd."
-  default     = "pd-ssd"
+  default     = "standard"
 }
 
 variable "gke_sc_gitlab_restore_disk" {
   type        = string
   description = "Storage class for Perstistent Volume used for extra space in Backup Restore Job. Default pd-sdd."
-  default     = "pd-ssd"
+  default     = "standard"
 }
 
 variable "gke_cluster_resource_labels" {

--- a/variables.tf
+++ b/variables.tf
@@ -119,12 +119,6 @@ variable "redis_size" {
 #  GCS SECTION   #
 ##################
 
-variable "gcs_bucket_random_suffix" {
-  type        = bool
-  description = "Sets random suffix at the end of the bucket name."
-  default     = false
-}
-
 variable "gcs_bucket_allow_force_destroy" {
   type        = bool
   default     = false
@@ -140,13 +134,13 @@ variable "gcs_bucket_storage_class" {
 variable "gcs_bucket_versioning" {
   type        = bool
   description = "Setup Object Storage versioning for all Bucket created."
-  default     = false
+  default     = true
 }
 
 variable "gcs_bucket_backup_sc_change" {
   type        = number
   description = "When the backup lifecycle is enabled, set the number of days after the storage class changes to coldline"
-  default     = 14
+  default     = 30
 }
 
 variable "gcs_bucket_backup_duration" {


### PR DESCRIPTION
Refactoring Bucket Creation 

 - Versioning toggle 
 - force destroy variable changed name with a more intuitive one. 
 - default standard storage class for backup pv
 - Lifecycle for backup bucket only. Switch to coldline sc after 14 days , delete after 120 days. 
 
 This PR is a Breaking change for bucket creation and naming. 