### PR TITLE
refs platfrom/1671: Add Labels to DB and Buckets - Migration - Gitaly PV 

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Then perform the following commands on the root folder:
 | gcs\_bucket\_target\_storage\_class | The target Storage Class of objects affected by this Lifecycle Rule. Supported values include: STANDARD, MULTI\_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE. | `string` | `"COLDLINE"` | no |
 | gcs\_bucket\_versioning | Setup Object Storage versioning for all Bucket created. | `bool` | `true` | no |
 | gitab\_enable\_migrations | Enable migrations sub chart | `bool` | `true` | no |
+| gitab\_enable\_prom\_exporter | Enable gitlab prometheus exporter | `bool` | `false` | no |
 | gitlab\_address\_name | Name of the address to use for GitLab ingress | `string` | `""` | no |
 | gitlab\_backup\_extra\_args | Add a string of extra arguments for the gitlab backup-utility. | `string` | `""` | no |
 | gitlab\_backup\_pv\_size | Set the size of the additional storage for Backup TAR Creation | `number` | `100` | no |
@@ -57,7 +58,7 @@ Then perform the following commands on the root folder:
 | gitlab\_enable\_registry | Choose whether to enable Gitlab Container registry. Default to false. | `bool` | `false` | no |
 | gitlab\_enable\_restore\_pv | Enable additional storage for TAR Restoration creation of any appreciable size | `bool` | `false` | no |
 | gitlab\_enable\_smtp | Setup Gitlab email address to send email. | `bool` | `false` | no |
-| gitlab\_gitaly\_disk\_size | Setup persistent disk size for gitaly data in GB. Default 200 GB | `number` | `100` | no |
+| gitlab\_gitaly\_disk\_size | Setup persistent disk size for gitaly data in GB. Default 100 GB | `number` | `100` | no |
 | gitlab\_hpa\_max\_replicas\_kas | Set the maximum hpa pod replicas for the Gitlab Kas. | `number` | `10` | no |
 | gitlab\_hpa\_max\_replicas\_registry | Set the maximum hpa pod replicas for the Gitlab Registry. | `number` | `10` | no |
 | gitlab\_hpa\_max\_replicas\_shell | Set the maximum hpa pod replicas for the Gitlab Shell. | `number` | `10` | no |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Then perform the following commands on the root folder:
 | gcs\_bucket\_storage\_class | Bucket storage class. Supported values include: STANDARD, MULTI\_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE | `string` | `"STANDARD"` | no |
 | gcs\_bucket\_target\_storage\_class | The target Storage Class of objects affected by this Lifecycle Rule. Supported values include: STANDARD, MULTI\_REGIONAL, REGIONAL, NEARLINE, COLDLINE, ARCHIVE. | `string` | `"COLDLINE"` | no |
 | gcs\_bucket\_versioning | Setup Object Storage versioning for all Bucket created. | `bool` | `true` | no |
+| gitab\_enable\_migrations | Enable migrations sub chart | `bool` | `true` | no |
 | gitlab\_address\_name | Name of the address to use for GitLab ingress | `string` | `""` | no |
 | gitlab\_backup\_extra\_args | Add a string of extra arguments for the gitlab backup-utility. | `string` | `""` | no |
 | gitlab\_backup\_pv\_size | Set the size of the additional storage for Backup TAR Creation | `number` | `100` | no |
@@ -84,6 +85,7 @@ Then perform the following commands on the root folder:
 | gke\_enable\_cloudrun | Enable Google Cloudrun on GKE Cluster. Default false | `bool` | `false` | no |
 | gke\_enable\_image\_stream | Google Container File System (gcfs) has to be enabled for image streaming to be active. Needs image\_type to be set to COS\_CONTAINERD. | `bool` | `false` | no |
 | gke\_enable\_istio\_addon | Enable Istio addon | `bool` | `false` | no |
+| gke\_gitaly\_pv\_labels | The GITALY Persistent Volume labels (a map of key/value pairs comma separeted) to match against when choosing a volume to bind. This is used in the PersistentVolumeClaim selector section | `map(string)` | `{}` | no |
 | gke\_google\_group\_rbac\_mail | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `"null"` | no |
 | gke\_istio\_auth | The authentication type between services in Istio | `string` | `"AUTH_MUTUAL_TLS"` | no |
 | gke\_machine\_type | Machine type used for the node-pool | `string` | `"n1-standard-4"` | no |

--- a/main.tf
+++ b/main.tf
@@ -184,6 +184,7 @@ resource "google_sql_database_instance" "gitlab_db" {
     disk_size         = var.postgresql_disk_size
     disk_type         = var.postgresql_disk_type
     disk_autoresize   = true
+    user_labels       = var.gke_cluster_resource_labels
 
     ip_configuration {
       ipv4_enabled    = "false"
@@ -254,6 +255,7 @@ resource "google_storage_bucket" "gitlab_bucket" {
   location      = var.region
   storage_class = var.gcs_bucket_storage_class
   force_destroy = var.gcs_bucket_allow_force_destroy
+  labels        = var.gke_cluster_resource_labels
 
   versioning {
     enabled = var.gcs_bucket_versioning
@@ -537,6 +539,8 @@ data "template_file" "helm_values" {
     RESTORE_PV_SIZE       = var.gitlab_restore_pv_size
     BACKUP_PV_SC          = var.gke_sc_gitlab_backup_disk
     RESTORE_PV_SC         = var.gke_sc_gitlab_restore_disk
+    PV_MATCH_LABEL        = var.gke_gitaly_pv_labels[""]
+    ENABLE_MIGRATIONS     = var.gitab_enable_migrations
 
     #Bucket Names
     ARTIFACTS_BCKT    = google_storage_bucket.gitlab_bucket["artifacts"].name

--- a/main.tf
+++ b/main.tf
@@ -539,7 +539,7 @@ data "template_file" "helm_values" {
     RESTORE_PV_SIZE       = var.gitlab_restore_pv_size
     BACKUP_PV_SC          = var.gke_sc_gitlab_backup_disk
     RESTORE_PV_SC         = var.gke_sc_gitlab_restore_disk
-    PV_MATCH_LABEL        = yamlencode(var.gke_gitaly_pv_labels)
+    PV_MATCH_LABEL        = var.gke_gitaly_pv_labels
     ENABLE_MIGRATIONS     = var.gitab_enable_migrations
     ENABLE_PROM_EXPORTER  = var.gitab_enable_prom_exporter
 

--- a/main.tf
+++ b/main.tf
@@ -541,6 +541,7 @@ data "template_file" "helm_values" {
     RESTORE_PV_SC         = var.gke_sc_gitlab_restore_disk
     PV_MATCH_LABEL        = yamlencode(var.gke_gitaly_pv_labels)
     ENABLE_MIGRATIONS     = var.gitab_enable_migrations
+    ENABLE_PROM_EXPORTER  = var.gitab_enable_prom_exporter
 
     #Bucket Names
     ARTIFACTS_BCKT    = google_storage_bucket.gitlab_bucket["artifacts"].name

--- a/main.tf
+++ b/main.tf
@@ -539,7 +539,7 @@ data "template_file" "helm_values" {
     RESTORE_PV_SIZE       = var.gitlab_restore_pv_size
     BACKUP_PV_SC          = var.gke_sc_gitlab_backup_disk
     RESTORE_PV_SC         = var.gke_sc_gitlab_restore_disk
-    PV_MATCH_LABEL        = var.gke_gitaly_pv_labels[""]
+    PV_MATCH_LABEL        = yamlencode(var.gke_gitaly_pv_labels)
     ENABLE_MIGRATIONS     = var.gitab_enable_migrations
 
     #Bucket Names

--- a/values.yaml
+++ b/values.yaml
@@ -234,4 +234,5 @@ gitlab:
     persistence:
       size: "${GITALY_PV_SIZE}Gi"
       storageClass: ${PV_STORAGE_CLASS}
-      matchLabels: {${PV_MATCH_LABEL}}
+      matchLabels:
+        {${PV_MATCH_LABEL}}

--- a/values.yaml
+++ b/values.yaml
@@ -237,4 +237,4 @@ gitlab:
       size: "${GITALY_PV_SIZE}Gi"
       storageClass: ${PV_STORAGE_CLASS}
       matchLabels:
-        {${PV_MATCH_LABEL}}
+        ${PV_MATCH_LABEL}

--- a/values.yaml
+++ b/values.yaml
@@ -206,6 +206,8 @@ gitlab:
     maxReplicas: ${HPA_MAX_REPLICAS_SIDEKIQ}
   migrations:
     enabled: ${ENABLE_MIGRATIONS}
+  gitlab-exporter:
+    enabled: ${ENABLE_PROM_EXPORTER}
   ## https://docs.gitlab.com/charts/charts/gitlab/toolbox
   toolbox:
     backups:

--- a/values.yaml
+++ b/values.yaml
@@ -240,4 +240,3 @@ gitlab:
         %{ for key, value in PV_MATCH_LABEL ~}
         ${key}: ${value}
         %{ endfor ~}
-        

--- a/values.yaml
+++ b/values.yaml
@@ -204,6 +204,8 @@ gitlab:
   sidekiq:
     minReplicas: ${HPA_MIN_REPLICAS_SIDEKIQ}
     maxReplicas: ${HPA_MAX_REPLICAS_SIDEKIQ}
+  migrations:
+    enabled: ${ENABLE_MIGRATIONS}
   ## https://docs.gitlab.com/charts/charts/gitlab/toolbox
   toolbox:
     backups:
@@ -232,3 +234,4 @@ gitlab:
     persistence:
       size: "${GITALY_PV_SIZE}Gi"
       storageClass: ${PV_STORAGE_CLASS}
+      matchLabels: {${PV_MATCH_LABEL}}

--- a/values.yaml
+++ b/values.yaml
@@ -237,4 +237,7 @@ gitlab:
       size: "${GITALY_PV_SIZE}Gi"
       storageClass: ${PV_STORAGE_CLASS}
       matchLabels:
-        ${PV_MATCH_LABEL}
+        %{ for key, value in PV_MATCH_LABEL ~}
+        ${key}: ${value}
+        %{ endfor ~}
+        

--- a/variables.tf
+++ b/variables.tf
@@ -419,7 +419,7 @@ variable "gitlab_schedule_cron_backup" {
 
 variable "gitlab_gitaly_disk_size" {
   type        = number
-  description = "Setup persistent disk size for gitaly data in GB. Default 200 GB"
+  description = "Setup persistent disk size for gitaly data in GB. Default 100 GB"
   default     = 100
 }
 
@@ -457,6 +457,12 @@ variable "gitab_enable_migrations" {
   type        = bool
   description = "Enable migrations sub chart"
   default     = true
+}
+
+variable "gitab_enable_prom_exporter" {
+  type        = bool
+  description = "Enable gitlab prometheus exporter"
+  default     = false
 }
 
 # Peformance optimization. Max and min pod replicas for HPA.

--- a/variables.tf
+++ b/variables.tf
@@ -281,7 +281,7 @@ variable "gke_cluster_resource_labels" {
 
 variable "gke_gitaly_pv_labels" {
   type        = map(string)
-  description = "The GITALY Persistent Volume labels (a map of key/value pairs) to match against when choosing a volume to bind. This is used in the PersistentVolumeClaim selector section"
+  description = "The GITALY Persistent Volume labels (a map of key/value pairs comma separeted) to match against when choosing a volume to bind. This is used in the PersistentVolumeClaim selector section"
   default     = {}
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -279,6 +279,12 @@ variable "gke_cluster_resource_labels" {
   default     = {}
 }
 
+variable "gke_gitaly_pv_labels" {
+  type        = map(string)
+  description = "The GITALY Persistent Volume labels (a map of key/value pairs) to match against when choosing a volume to bind. This is used in the PersistentVolumeClaim selector section"
+  default     = {}
+}
+
 ##################
 # GITLAB SECTION #
 ##################
@@ -445,6 +451,12 @@ variable "gitlab_restore_pv_size" {
   type        = number
   description = "Set the size of the additional storage for Backup TAR Restoration Process"
   default     = 100
+}
+
+variable "gitab_enable_migrations" {
+  type        = bool
+  description = "Enable migrations sub chart"
+  default     = true
 }
 
 # Peformance optimization. Max and min pod replicas for HPA.


### PR DESCRIPTION
Setup same label fro gke resource to DB and Buckets. 
Setting for Gitaly PV label (useful for restore procedure). 



