### PR TITLE
refs platform/3154: fix behavior secret generation for service desk

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -598,7 +598,7 @@ module "gitlab_servicedesk_pass" {
   k8s_secret_name = local.gitlab_servicedesk_k8ssecret
   k8s_secret_key  = "password"
 
-  count      = var.gitlab_enable_service_desk ? 1 : 0
+  count      = length(var.gitlab_service_desk_mail_address) > 0 ? 1 : 0
   depends_on = [kubernetes_namespace.gitlab_namespace]
 }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Improved service desk secret generation logic by basing it on the presence of a service desk mail address rather than a simple enable flag
- Changed condition from `gitlab_enable_service_desk` to `length(var.gitlab_service_desk_mail_address) > 0`
- This change makes the secret generation more precise and dependent on actual configuration rather than just a flag



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Update service desk secret generation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<li>Changed service desk secret generation condition from <br><code>gitlab_enable_service_desk</code> flag to checking length of <br><code>gitlab_service_desk_mail_address</code><br> <li> Updated local variable <code>gitlab_servicedesk_k8ssecret</code> to use the same <br>condition<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/86/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information