### PR TITLE
feat: add GKE default service account as output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -77,3 +77,8 @@ output "gitlab_namespace" {
   value       = var.gitlab_namespace
   description = "The namespace where Gitlab is installed."
 }
+
+output "gke_service_account" {
+  value       = module.gke.service_account
+  description = "The service account used by the GKE cluster."
+}


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Exposes the GKE cluster's default service account as a new output variable
- Enables external access to the service account information for further configuration or integration



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>outputs.tf</strong><dd><code>Add GKE service account output variable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

outputs.tf

<li>Added new output variable <code>gke_service_account</code> to expose the GKE <br>cluster's service account<br>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/88/files#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information