### PR TITLE
refs platform/#3312: Add private IP Google access to GitLab subnet

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -107,10 +107,11 @@ resource "google_compute_network" "gitlab" {
 }
 
 resource "google_compute_subnetwork" "subnetwork" {
-  name          = "gitlab"
-  ip_cidr_range = var.gke_nodes_subnet_cidr
-  region        = var.region
-  network       = google_compute_network.gitlab.self_link
+  name                     = "gitlab"
+  ip_cidr_range            = var.gke_nodes_subnet_cidr
+  region                   = var.region
+  network                  = google_compute_network.gitlab.self_link
+  private_ip_google_access = true
 
   secondary_ip_range {
     range_name    = local.subnet_name_pod_cidr

--- a/outputs.tf
+++ b/outputs.tf
@@ -82,3 +82,8 @@ output "gke_service_account" {
   value       = module.gke.service_account
   description = "The service account used by the GKE cluster."
 }
+
+output "gitlab_subnet_selflink" {
+  value       = google_compute_subnetwork.subnetwork
+  description = "The self link of the subnet used by the GKE cluster."
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -84,6 +84,6 @@ output "gke_service_account" {
 }
 
 output "gitlab_subnet_selflink" {
-  value       = google_compute_subnetwork.subnetwork
+  value       = google_compute_subnetwork.subnetwork.self_link
   description = "The self link of the subnet used by the GKE cluster."
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Enable private IP Google access for GitLab subnet

- Add subnet self link output for reference


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Enable private IP Google access for GitLab subnet</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<li>Added <code>private_ip_google_access = true</code> to the GitLab subnetwork <br>resource<br> <li> Reformatted resource attributes alignment for better readability


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/95/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>outputs.tf</strong><dd><code>Add GitLab subnet self link output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

outputs.tf

<li>Added new output <code>gitlab_subnet_selflink</code> that exposes the self link of <br>the GitLab subnet<br> <li> Included description explaining the output is for the subnet used by <br>the GKE cluster


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/95/files#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>