### PR TITLE
refs platform/#3312: Add output for GitLab network self link

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -87,3 +87,8 @@ output "gitlab_subnet_selflink" {
   value       = google_compute_subnetwork.subnetwork.self_link
   description = "The self link of the subnet used by the GKE cluster."
 }
+
+output "gitlab_network_selflink" {
+  value       = google_compute_network.gitlab.self_link
+  description = "The self link of the network used by the GKE cluster."
+}


### PR DESCRIPTION
### **User description**
…form configuration


___

### **PR Type**
Enhancement


___

### **Description**
- Add output for GitLab network self link


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>outputs.tf</strong><dd><code>Add GitLab network self link output</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

outputs.tf

<li>Added new output <code>gitlab_network_selflink</code> that exposes the self link of <br>the network used by the GKE cluster<br> <li> Complements existing <code>gitlab_subnet_selflink</code> output


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/96/files#diff-de6c47c2496bd028a84d55ab12d8a4f90174ebfb6544b8b5c7b07a7ee4f27ec7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>