### PR TITLE
fix: keep SYSTEM_COMPONENTS monitoring when enabling managed prometheus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Fix - refs sparkfabrik-innovation-team/board#4565: keep `SYSTEM_COMPONENTS` monitoring when enabling managed Prometheus. Enabling `gke_monitoring_enable_managed_prometheus` activates the cluster `monitoring_config` block, whose `enable_components` defaults to empty and previously dropped GKE system metrics. A new `gke_monitoring_enabled_components` variable (default `["SYSTEM_COMPONENTS"]`) is now applied so system metrics are retained.
+
 ## [2.33.0] - 2026-06-30
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Then perform the following commands on the root folder:
 | gke\_max\_node\_count | Define the maximum number of nodes of the autoscaling cluster. Default 5 | `number` | `5` | no |
 | gke\_min\_node\_count | Define the minimum number of nodes of the autoscaling cluster. Default 1 | `number` | `1` | no |
 | gke\_monitoring\_enable\_managed\_prometheus | Whether Google Managed Service for Prometheus managed collection is enabled on the cluster. | `bool` | `false` | no |
+| gke\_monitoring\_enabled\_components | Monitoring components to enable when managed collection is on. Defaults to SYSTEM\_COMPONENTS so enabling managed Prometheus does not disable GKE system metrics. Only applied when gke\_monitoring\_enable\_managed\_prometheus is true. | `list(string)` | <pre>[<br/>  "SYSTEM\_COMPONENTS"<br/>]</pre> | no |
 | gke\_node\_count | Define the number of nodes of the cluster. Default 1 | `number` | `1` | no |
 | gke\_node\_pool\_description | Description of the node pool for the GitLab cluster | `string` | `"Gitlab Cluster"` | no |
 | gke\_node\_pool\_name | Name of the node pool for the GitLab cluster | `string` | `"gitlab"` | no |

--- a/main.tf
+++ b/main.tf
@@ -387,8 +387,12 @@ module "gke" {
 
   cluster_autoscaling = var.gke_cluster_autoscaling
 
-  # Google Managed Service for Prometheus (managed collection)
+  # Google Managed Service for Prometheus (managed collection).
+  # Enabling managed collection activates the cluster monitoring_config block,
+  # whose enable_components defaults to empty. Set the components explicitly so
+  # GKE system metrics are retained instead of being dropped.
   monitoring_enable_managed_prometheus = var.gke_monitoring_enable_managed_prometheus
+  monitoring_enabled_components        = var.gke_monitoring_enable_managed_prometheus ? var.gke_monitoring_enabled_components : []
 
   node_pools = concat(
     [

--- a/variables.tf
+++ b/variables.tf
@@ -383,6 +383,12 @@ variable "gke_monitoring_enable_managed_prometheus" {
   default     = false
 }
 
+variable "gke_monitoring_enabled_components" {
+  type        = list(string)
+  description = "Monitoring components to enable when managed collection is on. Defaults to SYSTEM_COMPONENTS so enabling managed Prometheus does not disable GKE system metrics. Only applied when gke_monitoring_enable_managed_prometheus is true."
+  default     = ["SYSTEM_COMPONENTS"]
+}
+
 variable "gke_enable_istio_addon" {
   type        = bool
   description = "Enable Istio addon"


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Problem

Enabling `gke_monitoring_enable_managed_prometheus` (added in v2.33.0) flips the upstream module's `logmon_config_is_set`, activating the cluster `monitoring_config` block. That block sets `enable_components = var.monitoring_enabled_components` (default empty), so `SYSTEM_COMPONENTS` (previously from `monitoring_service`) is dropped, silently disabling GKE system metrics when a consumer turns managed Prometheus on.

A real `terraform plan` showed:

```
~ monitoring_config {
    ~ enable_components = [ - "SYSTEM_COMPONENTS" ]
    + managed_prometheus { enabled = true }
  }
```

## Fix

Add `gke_monitoring_enabled_components` (default `["SYSTEM_COMPONENTS"]`), applied to `monitoring_enabled_components` only when managed Prometheus is enabled:

```hcl
monitoring_enabled_components = var.gke_monitoring_enable_managed_prometheus ? var.gke_monitoring_enabled_components : []
```

Enabling managed Prometheus now keeps system metrics; consumers not using it are unaffected.

Refs: sparkfabrik-innovation-team/board#4565


___

### **PR Type**
Bug fix


___

### **Description**
- Fix silent drop of `SYSTEM_COMPONENTS` when enabling managed Prometheus

- Add `gke_monitoring_enabled_components` variable (default `["SYSTEM_COMPONENTS"]`)

- Apply components only when `gke_monitoring_enable_managed_prometheus` is true

- Update CHANGELOG and README documentation accordingly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gke_monitoring_enable_managed_prometheus = true"] -- "activates" --> B["monitoring_config block"]
  B -- "previously dropped" --> C["SYSTEM_COMPONENTS metrics"]
  D["gke_monitoring_enabled_components\n(default: SYSTEM_COMPONENTS)"] -- "now explicitly set" --> B
  B -- "now retains" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Explicitly set monitoring components when managed Prometheus enabled</code></dd></summary>
<hr>

main.tf

<ul><li>Added <code>monitoring_enabled_components</code> assignment using a conditional <br>expression<br> <li> When managed Prometheus is enabled, passes <br><code>var.gke_monitoring_enabled_components</code>; otherwise passes empty list<br> <li> Added explanatory comment about why components must be set explicitly</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/120/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Add gke_monitoring_enabled_components variable with SYSTEM_COMPONENTS </code><br><code>default</code></dd></summary>
<hr>

variables.tf

<ul><li>Added new <code>gke_monitoring_enabled_components</code> variable of type <br><code>list(string)</code><br> <li> Default value is <code>["SYSTEM_COMPONENTS"]</code> to preserve GKE system metrics<br> <li> Includes description clarifying it only applies when managed <br>Prometheus is enabled</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/120/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document SYSTEM_COMPONENTS monitoring fix in changelog</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added entry under <code>Unreleased > Fixed</code> describing the bug and fix<br> <li> References the internal board issue and explains the new variable</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/120/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document new gke_monitoring_enabled_components variable in README</code></dd></summary>
<hr>

README.md

<ul><li>Added row for <code>gke_monitoring_enabled_components</code> variable in the inputs <br>table<br> <li> Documents type, default value, and description for the new variable</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/120/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

