### PR TITLE
fix: mount psql client cert into gitlab-exporter for SSL DB probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Fix - refs https://gitlab.sparkfabrik.com/sparkfabrik-innovation-team/board/-/work_items/4574: enable SSL (mTLS) for the gitlab-exporter database connection. Mount the `postgresql-ssl-secrets` volume into the exporter's main container at `/etc/gitlab/postgres/ssl` and set `PGSSLMODE=verify-ca`, so its Postgres probes work against a Cloud SQL instance that requires a client certificate. Only applied when the exporter is enabled (`gitab_enable_prom_exporter`).
+
 ## [2.34.0] - 2026-06-30
 
 ### Fixed

--- a/values.yaml
+++ b/values.yaml
@@ -256,6 +256,22 @@ gitlab:
     enabled: ${ENABLE_MIGRATIONS}
   gitlab-exporter:
     enabled: ${ENABLE_PROM_EXPORTER}
+    # gitlab-exporter's DB probes fail against a Cloud SQL instance that requires
+    # a client certificate. Root cause: the chart mounts the psql client cert
+    # only in the exporter's `configure` init container, not its main container,
+    # so libpq cannot present it and falls back to a non-SSL connection that
+    # pg_hba rejects. The postgresql-ssl-secrets volume already exists at pod
+    # level; mounting it into the main container is the fix (verified with psql:
+    # with the certs present, libpq negotiates SSL and connects). PGSSLMODE
+    # forces + verifies SSL like the Rails apps; PGSSLCERT/PGSSLKEY/PGSSLROOTCERT
+    # already come from global.extraEnv. Related upstream gap:
+    # https://gitlab.com/gitlab-org/charts/gitlab/-/issues/1817
+    extraVolumeMounts: |
+      - name: postgresql-ssl-secrets
+        mountPath: /etc/gitlab/postgres/ssl
+        readOnly: true
+    extraEnv:
+      PGSSLMODE: verify-ca
   ## https://docs.gitlab.com/charts/charts/gitlab/toolbox
   toolbox:
 %{ if length(BACKUP_JOB_VOLUME_FSGROUP_POLICY) > 0 ~}


### PR DESCRIPTION
> :robot: _This was written by an AI agent on behalf of @paolomainardi._

## Problem
gitlab-exporter's PostgreSQL probes fail against a Cloud SQL instance that requires a client certificate:
```
FATAL: pg_hba.conf rejects connection ... user "gitlab", db "gitlabhq_production", no encryption
```
Only its Redis (sidekiq) + ruby probes work.

## Root cause (verified live, not from docs)
Checked the running exporter pod:
- It **already has** `PGSSLCERT/PGSSLKEY/PGSSLROOTCERT` env (from `global.extraEnv`).
- But `/etc/gitlab/postgres/ssl/` **does not exist in its main container** — the chart mounts the psql client cert only in the exporter's `configure` init container.

So libpq can't read the cert files the env points to and, at the default `sslmode`, **falls back to a non-SSL connection** that `pg_hba` rejects.

## Proof
From the toolbox pod (certs present, same `PGSSL*` env), an exporter-style connection string (no inline ssl params):
- without `PGSSLMODE` → `SHOW ssl` = **on** (certs present ⇒ libpq negotiates SSL)
- with `PGSSLMODE=verify-ca` → `SHOW ssl` = **on**, `SELECT 1` = **1**

This confirms the missing cert **mount** is the fix; `PGSSLMODE` is hardening.

## Change
Under `gitlab.gitlab-exporter` in `values.yaml` (the main container renders `extraVolumeMounts`/`extraEnv`, and the `postgresql-ssl-secrets` volume already exists at pod level):
- mount `postgresql-ssl-secrets` at `/etc/gitlab/postgres/ssl` — **the fix**
- set `PGSSLMODE: verify-ca` — force + verify SSL like the Rails apps

Values-only, no new module variable, only when the exporter is enabled. Related upstream gap: https://gitlab.com/gitlab-org/charts/gitlab/-/issues/1817

## After merge
Release the module, bump the ref in the gitlab-platform repo, apply, and confirm the exporter DB probes turn green (no `pg_hba` errors; `ci_builds`/row-count metrics appear).

Refs: https://gitlab.sparkfabrik.com/sparkfabrik-innovation-team/board/-/work_items/4574