### PR TITLE
feat(gke): support per-nodepool private or public nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Added
+
+- `gke_enable_private_nodes` variable (default `true`) controlling whether cluster nodes are private (internal IP only) by default.
+- `gke_node_pool_enable_private_nodes` variable (default `null`) overriding `enable_private_nodes` for the default GitLab node pool; set to `false` for a node pool with ephemeral (public) external IPs.
+- `enable_private_nodes` key support per pool in `gke_additional_node_pools`, allowing individual node pools to be public or private.
+
+### Changed
+
+- Bump `terraform-google-modules/kubernetes-engine` GKE module from `~> 34.0.0` to `~> 37.0`.
+- Raise the `google` and `google-beta` provider floor to `>= 6.38.0` (still `< 7.0.0`), required by the GKE module bump.
+- Replace the removed Cloud SQL `require_ssl = true` argument with `ssl_mode = "ENCRYPTED_ONLY"`, required by the `google` 6.x provider; SSL enforcement is unchanged.
+
 ## [2.34.2] - 2026-07-01
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 - `gke_enable_private_nodes` variable (default `true`) controlling whether cluster nodes are private (internal IP only) by default.
 - `gke_node_pool_enable_private_nodes` variable (default `null`) overriding `enable_private_nodes` for the default GitLab node pool; set to `false` for a node pool with ephemeral (public) external IPs.
 - `enable_private_nodes` key support per pool in `gke_additional_node_pools`, allowing individual node pools to be public or private.
+- `gke_master_ipv4_cidr_block` variable (default `null`) passing the control-plane (hosted master) CIDR to the GKE module, so the master-webhook firewall rule sources from the control-plane range on private clusters.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 - Bump `terraform-google-modules/kubernetes-engine` GKE module from `~> 34.0.0` to `~> 37.0`.
 - Raise the `google` and `google-beta` provider floor to `>= 6.38.0` (still `< 7.0.0`), required by the GKE module bump.
-- Replace the removed Cloud SQL `require_ssl = true` argument with `ssl_mode = "ENCRYPTED_ONLY"`, required by the `google` 6.x provider; SSL enforcement is unchanged.
+- Replace the removed Cloud SQL `require_ssl = true` argument with `ssl_mode = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"`, required by the `google` 6.x provider. This is the documented equivalent of `require_ssl = true`, so the database keeps requiring encrypted connections with valid client certificates.
 
 ## [2.34.2] - 2026-07-01
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Then perform the following commands on the root folder:
 | gitlab\_smtp\_user | Setup email sender address for Gitlab smtp server to send emails. | `string` | `"user@example.com"` | no |
 | gitlab\_time\_zone | Setup timezone for gitlab containers | `string` | `"Europe/Rome"` | no |
 | gke\_add\_master\_webhook\_firewall\_rules | Create firewall rules to allow GKE master to communicate with cluster nodes for webhook functionality. Default true | `bool` | `true` | no |
-| gke\_additional\_node\_pools | Additional node pools to create in the cluster | `list(map(any))` | `[]` | no |
+| gke\_additional\_node\_pools | Additional node pools to create in the cluster. Each pool may set `enable_private_nodes` (bool) to control whether its nodes are private (internal IP only) or public (ephemeral external IPs); when omitted the pool inherits the cluster-level `gke_enable_private_nodes`. | `list(map(any))` | `[]` | no |
 | gke\_auto\_repair | Enable auto repair for the cluster. Default true | `bool` | `true` | no |
 | gke\_auto\_scaling | Enable auto scaling for the cluster. Default true | `bool` | `true` | no |
 | gke\_auto\_upgrade | Enable auto upgrade for the cluster. Default true | `bool` | `true` | no |
@@ -129,6 +129,7 @@ Then perform the following commands on the root folder:
 | gke\_enable\_image\_stream | Google Container File System (gcfs) has to be enabled for image streaming to be active. Needs image\_type to be set to COS\_CONTAINERD. | `bool` | `false` | no |
 | gke\_enable\_istio\_addon | Enable Istio addon | `bool` | `false` | no |
 | gke\_enable\_pod\_security\_policy | Enable Pod Security Policy for the cluster. Default false | `bool` | `false` | no |
+| gke\_enable\_private\_nodes | Whether nodes have internal IP addresses only (private nodes) at the cluster level. When true, the cluster defaults to private nodes; individual node pools can still opt out via `gke_node_pool_enable_private_nodes` or the `enable_private_nodes` key in `gke_additional_node_pools`. Set to false to give nodes ephemeral (public) external IPs by default. | `bool` | `true` | no |
 | gke\_gce\_pd\_csi\_driver | Enable GCE Persistent Disk CSI Driver for GKE Cluster. Default true | `bool` | `true` | no |
 | gke\_gitaly\_pv\_labels | The GITALY Persistent Volume labels (a map of key/value pairs comma separeted) to match against when choosing a volume to bind. This is used in the PersistentVolumeClaim selector section | `map(string)` | `{}` | no |
 | gke\_google\_group\_rbac\_mail | The name of the RBAC security group for use with Google security groups in Kubernetes RBAC. Group name must be in format gke-security-groups@yourdomain.com | `string` | `"null"` | no |
@@ -145,6 +146,7 @@ Then perform the following commands on the root folder:
 | gke\_monitoring\_enabled\_components | Monitoring components to enable when managed collection is on. Defaults to SYSTEM\_COMPONENTS so enabling managed Prometheus does not disable GKE system metrics. Only applied when gke\_monitoring\_enable\_managed\_prometheus is true. | `list(string)` | <pre>[<br/>  "SYSTEM\_COMPONENTS"<br/>]</pre> | no |
 | gke\_node\_count | Define the number of nodes of the cluster. Default 1 | `number` | `1` | no |
 | gke\_node\_pool\_description | Description of the node pool for the GitLab cluster | `string` | `"Gitlab Cluster"` | no |
+| gke\_node\_pool\_enable\_private\_nodes | Override `enable_private_nodes` for the default GitLab node pool. When null the pool inherits the cluster-level `gke_enable_private_nodes`. Set to false to give this pool ephemeral (public) external IPs, or true to force private nodes. | `bool` | `null` | no |
 | gke\_node\_pool\_name | Name of the node pool for the GitLab cluster | `string` | `"gitlab"` | no |
 | gke\_node\_pools\_labels | Map of maps containing node labels by node-pool name | `map(map(string))` | <pre>{<br>  "all": {},<br>  "default-node-pool": {}<br>}</pre> | no |
 | gke\_node\_pools\_taints | Map of lists containing node taints by node-pool name | `map(list(object({ key = string, value = string, effect = string })))` | <pre>{<br>  "gitlab": []<br>}</pre> | no |

--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Then perform the following commands on the root folder:
 | gke\_maintenance\_end\_time | End time for GKE maintenance window in RFC3339 format. | `string` | `"1970-01-01T04:30:00Z"` | no |
 | gke\_maintenance\_recurrence | Recurrence rule for the GKE maintenance window in RRULE format. | `string` | `"FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"` | no |
 | gke\_maintenance\_start\_time | Start time for GKE maintenance window in RFC3339 format. | `string` | `"1970-01-01T00:30:00Z"` | no |
+| gke\_master\_ipv4\_cidr\_block | The /28 CIDR of the GKE control plane (hosted master) private network. Set this for private clusters so the master-webhook firewall rule sources from the control-plane range; when null the module falls back to the node subnet CIDR, which is only populated when cluster firewall rules are enabled. Leave null for public clusters without a private control plane. | `string` | `null` | no |
 | gke\_max\_node\_count | Define the maximum number of nodes of the autoscaling cluster. Default 5 | `number` | `5` | no |
 | gke\_min\_node\_count | Define the minimum number of nodes of the autoscaling cluster. Default 1 | `number` | `1` | no |
 | gke\_monitoring\_enable\_managed\_prometheus | Whether Google Managed Service for Prometheus managed collection is enabled on the cluster. | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -195,7 +195,7 @@ resource "google_sql_database_instance" "gitlab_db" {
     ip_configuration {
       ipv4_enabled    = "false"
       private_network = google_compute_network.gitlab.self_link
-      ssl_mode        = "ENCRYPTED_ONLY"
+      ssl_mode        = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     }
 
     dynamic "database_flags" {

--- a/main.tf
+++ b/main.tf
@@ -414,7 +414,7 @@ module "gke" {
         preemptible                = var.gke_preemptible
         autoscaling                = var.gke_auto_scaling
         location_policy            = var.gke_location_policy
-        enable_private_nodes       = var.gke_node_pool_enable_private_nodes
+        enable_private_nodes       = coalesce(var.gke_node_pool_enable_private_nodes, var.gke_enable_private_nodes)
 
         #Image Streaming
         enable_gcfs = var.gke_enable_image_stream

--- a/main.tf
+++ b/main.tf
@@ -365,6 +365,7 @@ module "gke" {
   add_master_webhook_firewall_rules = var.gke_add_master_webhook_firewall_rules
   enable_private_endpoint           = false
   enable_private_nodes              = var.gke_enable_private_nodes
+  master_ipv4_cidr_block            = var.gke_master_ipv4_cidr_block
   release_channel                   = "STABLE"
   maintenance_start_time            = var.gke_maintenance_start_time
   maintenance_end_time              = var.gke_maintenance_end_time

--- a/main.tf
+++ b/main.tf
@@ -195,7 +195,7 @@ resource "google_sql_database_instance" "gitlab_db" {
     ip_configuration {
       ipv4_enabled    = "false"
       private_network = google_compute_network.gitlab.self_link
-      require_ssl     = "true"
+      ssl_mode        = "ENCRYPTED_ONLY"
     }
 
     dynamic "database_flags" {
@@ -348,7 +348,7 @@ resource "google_storage_bucket_iam_binding" "gitlab_bucket_iam_binding_admin" {
 # GKE Cluster
 module "gke" {
   source  = "terraform-google-modules/kubernetes-engine/google//modules/beta-private-cluster"
-  version = "~> 34.0.0"
+  version = "~> 37.0"
 
   # Create an implicit dependency on service activation
   project_id = module.project_services.project_id
@@ -364,7 +364,7 @@ module "gke" {
   ip_range_services                 = local.subnet_name_service_cidr
   add_master_webhook_firewall_rules = var.gke_add_master_webhook_firewall_rules
   enable_private_endpoint           = false
-  enable_private_nodes              = true
+  enable_private_nodes              = var.gke_enable_private_nodes
   release_channel                   = "STABLE"
   maintenance_start_time            = var.gke_maintenance_start_time
   maintenance_end_time              = var.gke_maintenance_end_time
@@ -413,6 +413,7 @@ module "gke" {
         preemptible                = var.gke_preemptible
         autoscaling                = var.gke_auto_scaling
         location_policy            = var.gke_location_policy
+        enable_private_nodes       = var.gke_node_pool_enable_private_nodes
 
         #Image Streaming
         enable_gcfs = var.gke_enable_image_stream

--- a/variables.tf
+++ b/variables.tf
@@ -215,6 +215,18 @@ variable "gke_node_pool_description" {
   default     = "Gitlab Cluster"
 }
 
+variable "gke_enable_private_nodes" {
+  type        = bool
+  description = "Whether nodes have internal IP addresses only (private nodes) at the cluster level. When true, the cluster defaults to private nodes; individual node pools can still opt out via `gke_node_pool_enable_private_nodes` or the `enable_private_nodes` key in `gke_additional_node_pools`. Set to false to give nodes ephemeral (public) external IPs by default."
+  default     = true
+}
+
+variable "gke_node_pool_enable_private_nodes" {
+  type        = bool
+  description = "Override `enable_private_nodes` for the default GitLab node pool. When null the pool inherits the cluster-level `gke_enable_private_nodes`. Set to false to give this pool ephemeral (public) external IPs, or true to force private nodes."
+  default     = null
+}
+
 variable "gke_node_count" {
   type        = number
   description = "Define the number of nodes of the cluster. Default 1"
@@ -459,7 +471,7 @@ variable "gke_location_policy" {
 
 variable "gke_additional_node_pools" {
   type        = list(map(any))
-  description = "Additional node pools to create in the cluster"
+  description = "Additional node pools to create in the cluster. Each pool may set `enable_private_nodes` (bool) to control whether its nodes are private (internal IP only) or public (ephemeral external IPs); when omitted the pool inherits the cluster-level `gke_enable_private_nodes`."
   default     = []
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -227,6 +227,12 @@ variable "gke_node_pool_enable_private_nodes" {
   default     = null
 }
 
+variable "gke_master_ipv4_cidr_block" {
+  type        = string
+  description = "The /28 CIDR of the GKE control plane (hosted master) private network. Set this for private clusters so the master-webhook firewall rule sources from the control-plane range; when null the module falls back to the node subnet CIDR, which is only populated when cluster firewall rules are enabled. Leave null for public clusters without a private control plane."
+  default     = null
+}
+
 variable "gke_node_count" {
   type        = number
   description = "Define the number of nodes of the cluster. Default 1"

--- a/versions.tf
+++ b/versions.tf
@@ -19,11 +19,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "< 7.0.0"
+      version = ">= 6.38.0, < 7.0.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "< 7.0.0"
+      version = ">= 6.38.0, < 7.0.0"
     }
     helm = {
       source  = "hashicorp/helm"


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Add per-nodepool public/private node control for GKE
  - New `gke_enable_private_nodes` cluster-level default variable
  - New `gke_node_pool_enable_private_nodes` override for default pool
  - Support `enable_private_nodes` key in `gke_additional_node_pools`

- Bump GKE module to `~> 37.0`, raise google/google-beta provider floor to `>= 6.38.0`

- Fix private cluster webhook firewall via new `gke_master_ipv4_cidr_block` variable

- Replace removed Cloud SQL `require_ssl` with `ssl_mode = "ENCRYPTED_ONLY"`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  varEnable["gke_enable_private_nodes"] -- "sets cluster default" --> gkeModule["module gke"]
  varPoolEnable["gke_node_pool_enable_private_nodes"] -- "overrides default pool" --> gkeModule
  varAddPools["gke_additional_node_pools.enable_private_nodes"] -- "per-pool override" --> gkeModule
  varMasterCidr["gke_master_ipv4_cidr_block"] -- "fixes webhook firewall source" --> gkeModule
  gkeModuleVersion["GKE module ~> 37.0"] -- "requires" --> providerFloor["google/google-beta >= 6.38.0"]
  providerFloor -- "removes require_ssl" --> sqlSsl["ssl_mode = ENCRYPTED_ONLY"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Wire private-nodes and master CIDR vars into GKE module</code>&nbsp; &nbsp; </dd></summary>
<hr>

main.tf

<ul><li>Replace deprecated Cloud SQL <code>require_ssl = "true"</code> with <code>ssl_mode = </code><br><code>"ENCRYPTED_ONLY"</code><br> <li> Bump GKE module version from <code>~> 34.0.0</code> to <code>~> 37.0</code><br> <li> Wire <code>enable_private_nodes</code> to <code>var.gke_enable_private_nodes</code> at cluster <br>level<br> <li> Add <code>master_ipv4_cidr_block = var.gke_master_ipv4_cidr_block</code> and <br>per-pool <code>enable_private_nodes</code> for the default node pool</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/123/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+5/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Add new variables for private nodes and master CIDR</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variables.tf

<ul><li>Add <code>gke_enable_private_nodes</code> variable (default <code>true</code>)<br> <li> Add <code>gke_node_pool_enable_private_nodes</code> variable (default <code>null</code>)<br> <li> Add <code>gke_master_ipv4_cidr_block</code> variable (default <code>null</code>)<br> <li> Update <code>gke_additional_node_pools</code> description to document <br><code>enable_private_nodes</code> key</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/123/files#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288e">+19/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>versions.tf</strong><dd><code>Bump provider version floor for GKE module compatibility</code>&nbsp; </dd></summary>
<hr>

versions.tf

<ul><li>Raise <code>google</code> provider version constraint to <code>>= 6.38.0, < 7.0.0</code><br> <li> Raise <code>google-beta</code> provider version constraint to <code>>= 6.38.0, < 7.0.0</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/123/files#diff-dfd5848fa77a04d0343891fe859286cc210473d10f0e62c7f99f0d5ecf1a9927">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Update changelog for private-nodes feature and dependency bumps</code></dd></summary>
<hr>

CHANGELOG.md

<ul><li>Document new <code>gke_enable_private_nodes</code>, <br><code>gke_node_pool_enable_private_nodes</code> variables<br> <li> Document per-pool <code>enable_private_nodes</code> support<br> <li> Document GKE module and provider version bumps<br> <li> Document Cloud SQL <code>ssl_mode</code> replacement for <code>require_ssl</code></ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/123/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+12/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document new variables in README table</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Update <code>gke_additional_node_pools</code> description<br> <li> Document new <code>gke_enable_private_nodes</code> and <br><code>gke_node_pool_enable_private_nodes</code> variables in the table</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/123/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

