### PR TITLE
chore: release 2.35.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.35.0] - 2026-07-28
+
 ### Added
 
 - `gke_enable_private_nodes` variable (default `true`) controlling whether cluster nodes are private (internal IP only) by default.


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Syphon83._

## Summary

Cuts release 2.35.0 by promoting the accumulated `## Unreleased` entries under a dated `## [2.35.0] - 2026-07-28` heading in `CHANGELOG.md`. This is the only change: two inserted lines, no code touched.

A minor bump is correct because #123 added new module inputs (`gke_enable_private_nodes`, `gke_node_pool_enable_private_nodes`, `gke_master_ipv4_cidr_block`) without removing or renaming any existing input.

## What lands in 2.35.0

### Added

- Per-nodepool control over private versus public nodes, so a pool can run with ephemeral external IPs while the cluster stays private.
- `gke_master_ipv4_cidr_block`, letting the master-webhook firewall rule source from the control-plane range.

### Changed

- GKE module bumped from `~> 34.0.0` to `~> 37.0`, which is what provides native per-pool `enable_private_nodes`.
- `google` and `google-beta` provider floor raised to `>= 6.38.0` (still `< 7.0.0`), required by that module bump.
- Cloud SQL `require_ssl = true` replaced with `ssl_mode = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"`, the documented equivalent, because the `google` 6.x provider removed `require_ssl`.

## Consumer impact

Consumers pinning a `google` provider below 6.38.0 must upgrade before taking this release. The Cloud SQL change preserves the previous enforcement level: encrypted connections with valid client certificates are still required.

## Follow-up after merge

The `v2.35.0` git tag and GitHub release are created manually in this repository (there is no release workflow), so tagging is a separate step once this is merged.

Refs: sparkfabrik/terraform-sparkfabrik-gke-gitlab#123


___

### **PR Type**
Documentation


___

### **Description**
- Promote accumulated `## Unreleased` changelog entries under dated `## [2.35.0]` heading

- Release version 2.35.0 covering private-nodes feature and dependency bumps


___

### Diagram Walkthrough


```mermaid
  flowchart LR
    unreleased["## Unreleased entries"] -- "promoted under" --> release["## [2.35.0] - 2026-07-28"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Add 2.35.0 version heading to changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Insert <code>## [2.35.0] - 2026-07-28</code> version heading between <code>## Unreleased</code> <br>and <code>### Added</code><br> <li> Promote accumulated unreleased entries to the 2.35.0 release</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/124/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/z-ai/glm-5.2