### PR TITLE
fix(secrets): read secret versions at plan time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [2.35.1] - 2026-07-28
+
 ### Fixed
 
 - Stop the `secret_manager` submodule data source reads from being deferred to apply time. The five `gitlab_*_pass` module calls no longer carry a module level `depends_on` on `kubernetes_namespace.gitlab_namespace`, and instead take the namespace as a resource attribute so only `kubernetes_secret.k8s_secret` inherits the dependency. Previously any pending change inside `module.gke` made the four `google_secret_manager_secret_version` reads unknown at plan time, which in turn planned the `kubernetes_secret` payloads and `google_sql_user.gitlab.password` as changing on every cluster or node pool change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+### Fixed
+
+- Stop the `secret_manager` submodule data source reads from being deferred to apply time. The five `gitlab_*_pass` module calls no longer carry a module level `depends_on` on `kubernetes_namespace.gitlab_namespace`, and instead take the namespace as a resource attribute so only `kubernetes_secret.k8s_secret` inherits the dependency. Previously any pending change inside `module.gke` made the four `google_secret_manager_secret_version` reads unknown at plan time, which in turn planned the `kubernetes_secret` payloads and `google_sql_user.gitlab.password` as changing on every cluster or node pool change.
+
 ## [2.35.0] - 2026-07-28
 
 ### Added

--- a/main.tf
+++ b/main.tf
@@ -483,11 +483,9 @@ module "gitlab_db_pass" {
   project         = var.project_id
   region          = var.region
   secret_id       = var.gcp_existing_db_secret_name
-  k8s_namespace   = var.gitlab_namespace
+  k8s_namespace   = kubernetes_namespace.gitlab_namespace.metadata[0].name
   k8s_secret_name = "gitlab-postgres-secret"
   k8s_secret_key  = "password"
-
-  depends_on = [kubernetes_namespace.gitlab_namespace]
 }
 
 # Secret for External Object Storage (LFS, Artifacts, Uploads, etc..)
@@ -563,12 +561,11 @@ module "gitlab_smtp_pass" {
   project         = var.project_id
   region          = var.region
   secret_id       = var.gcp_existing_smtp_secret_name
-  k8s_namespace   = var.gitlab_namespace
+  k8s_namespace   = kubernetes_namespace.gitlab_namespace.metadata[0].name
   k8s_secret_name = "gitlab-smtp-secret"
   k8s_secret_key  = "password"
 
-  count      = var.gitlab_enable_smtp ? 1 : 0
-  depends_on = [kubernetes_namespace.gitlab_namespace]
+  count = var.gitlab_enable_smtp ? 1 : 0
 }
 
 #Secret for Omniauth Pass
@@ -577,12 +574,11 @@ module "gitlab_omniauth_pass" {
   project         = var.project_id
   region          = var.region
   secret_id       = var.gcp_existing_omniauth_secret_name
-  k8s_namespace   = var.gitlab_namespace
+  k8s_namespace   = kubernetes_namespace.gitlab_namespace.metadata[0].name
   k8s_secret_name = "gitlab-omniauth-secret"
   k8s_secret_key  = "provider"
 
-  count      = var.gitlab_enable_omniauth ? 1 : 0
-  depends_on = [kubernetes_namespace.gitlab_namespace]
+  count = var.gitlab_enable_omniauth ? 1 : 0
 }
 
 #Secret for Incoming Mail Pass
@@ -591,12 +587,11 @@ module "gitlab_incomingmail_pass" {
   project         = var.project_id
   region          = var.region
   secret_id       = var.gcp_existing_incomingmail_secret_name
-  k8s_namespace   = var.gitlab_namespace
+  k8s_namespace   = kubernetes_namespace.gitlab_namespace.metadata[0].name
   k8s_secret_name = local.gitlab_incomingmail_k8ssecret
   k8s_secret_key  = "password"
 
-  count      = var.gitlab_enable_incoming_mail ? 1 : 0
-  depends_on = [kubernetes_namespace.gitlab_namespace]
+  count = var.gitlab_enable_incoming_mail ? 1 : 0
 }
 
 #Secret for Service Desk Mail Pass
@@ -605,12 +600,11 @@ module "gitlab_servicedesk_pass" {
   project         = var.project_id
   region          = var.region
   secret_id       = var.gcp_existing_servicedesk_secret_name
-  k8s_namespace   = var.gitlab_namespace
+  k8s_namespace   = kubernetes_namespace.gitlab_namespace.metadata[0].name
   k8s_secret_name = local.gitlab_servicedesk_k8ssecret
   k8s_secret_key  = "password"
 
-  count      = var.gitlab_enable_service_desk ? 1 : 0
-  depends_on = [kubernetes_namespace.gitlab_namespace]
+  count = var.gitlab_enable_service_desk ? 1 : 0
 }
 
 data "google_compute_address" "gitlab" {


### PR DESCRIPTION
### **User description**
> :robot: _This was written by an AI agent on behalf of @Syphon83._

## Summary

Every change inside `module.gke` currently plans the four Kubernetes secret payloads and the Cloud SQL user password as changing, even when the stored secrets are untouched. This removes the dependency that causes it.

Reproduction is any cluster or node pool change on an otherwise clean state. The plan reports the intended change plus five extra ones:

```
~ module.gke.google_container_node_pool.pools["..."]     # the intended change
~ google_sql_user.gitlab                                # password (sensitive value)
~ module.gitlab_db_pass.kubernetes_secret.k8s_secret[0]           # data (sensitive value)
~ module.gitlab_smtp_pass[0].kubernetes_secret.k8s_secret[0]      # data
~ module.gitlab_omniauth_pass[0].kubernetes_secret.k8s_secret[0]  # data
~ module.gitlab_incomingmail_pass[0].kubernetes_secret.k8s_secret[0]  # data
```

Each of the four `google_secret_manager_secret_version` reads is reported as `will be read during apply`, with the note `(depends on a resource or a module with changes pending)`.

## Root cause

Two things compound.

**The data source inherits a dependency it does not need.** In `modules/secret_manager/main.tf` the read takes only plain strings:

```hcl
data "google_secret_manager_secret_version" "gcp_predefined_pass" {
  secret  = local.secret_id   # = var.secret_id
  project = var.project
  count   = var.secret_id != "" ? 1 : 0
}
```

Nothing in that configuration is unknown, so it can always resolve at plan time. But the five call sites declared `depends_on` at module level, and a module level `depends_on` propagates to every resource **and data source** inside the module. The only resource in the submodule that genuinely needs the namespace is `kubernetes_secret.k8s_secret`, and it received the namespace as a plain string, which is exactly why the `depends_on` was added.

**The chain reaches the whole GKE module.** `kubernetes_namespace.gitlab_namespace` depends on `time_sleep.sleep_for_cluster_fix_helm_6361`, which declares:

```hcl
depends_on = [module.gke.endpoint, google_sql_database.gitlabhq_production]
```

A `depends_on` that references a module output depends on the module as a whole, not on the named output, so `time_sleep` transitively depends on every resource in `module.gke`, node pools included.

Put together:

```
any pending change in module.gke
  -> time_sleep.sleep_for_cluster_fix_helm_6361
  -> kubernetes_namespace.gitlab_namespace
  -> module.gitlab_*_pass                       (module level depends_on)
  -> data.google_secret_manager_secret_version  deferred to apply
  -> local.secret_value unknown
  -> kubernetes_secret.data and google_sql_user.gitlab.password plan as changing
```

`google_sql_user.gitlab` is affected directly, since `password = module.gitlab_db_pass.secret_value`.

## The change

Pass the namespace as a resource attribute and drop the module level `depends_on`, at all five `gitlab_*_pass` call sites:

```diff
-  k8s_namespace   = var.gitlab_namespace
+  k8s_namespace   = kubernetes_namespace.gitlab_namespace.metadata[0].name
   k8s_secret_name = "gitlab-postgres-secret"
   k8s_secret_key  = "password"
-
-  depends_on = [kubernetes_namespace.gitlab_namespace]
 }
```

Only `kubernetes_secret.k8s_secret` consumes `k8s_namespace`, so only that resource inherits the dependency. That is the one place ordering is actually required: the namespace must exist before the secret is created. The data source keeps no dependency and resolves at plan time.

Nothing else in the submodule changes, and no variables or outputs are touched, so the generated documentation is unaffected.

## Verification

Applied the branch to a live deployment with an existing cluster and a pending node pool change, and compared plans on identical state.

Before, on `v2.35.0`:

```
Plan: 0 to add, 6 to change, 0 to destroy.
```

After, on this branch:

```
Plan: 0 to add, 1 to change, 0 to destroy.

# module.sf_gitlab_cn.module.gke.google_container_node_pool.pools["..."] will be updated in-place
~ network_config {
    ~ enable_private_nodes = true -> false
```

Only the intended change remains. The four data sources are read at plan time, and the secrets and the SQL user password no longer appear.

`terraform fmt -recursive -diff` reports no changes.

## Compatibility

No interface change, so this is a patch level fix.

The resolved namespace string is identical, `var.gitlab_namespace` either way, so `kubernetes_secret.metadata.namespace` does not change and existing deployments see no diff on the secrets themselves. Creation ordering on a fresh cluster is preserved, because the namespace is still a dependency of the secret resource.

## Notes for the reviewer

The same `depends_on = [kubernetes_namespace.gitlab_namespace]` pattern is used on the plain `kubernetes_secret` resources in the root module (`gitlab_rails_storage`, `gitlab_registry_storage`, `gitlab_gcs_credentials`, `postgresql_mtls_secret`). Those contain no data source, so the pattern is harmless there and this change leaves them alone.

Narrowing the `time_sleep` dependency would also break the chain and is worth considering separately. It is not included here because replacing that `depends_on` with a value reference means using `triggers`, which forces replacement of the `time_sleep` when the referenced values change. That is a behavioural change that deserves its own review, and it is not needed to fix the symptom.


___

### **PR Type**
Bug fix


___

### **Description**
- Removed module-level `depends_on` on `kubernetes_namespace.gitlab_namespace` from five `gitlab_*_pass` module calls

- Changed `k8s_namespace` from plain variable to resource attribute reference (`kubernetes_namespace.gitlab_namespace.metadata[0].name`)

- Prevents secret version reads from being deferred to apply time on unrelated GKE changes

- Added changelog entry documenting the fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["gitlab_*_pass modules"] -- "removed depends_on" --> B["kubernetes_namespace.gitlab_namespace"]
  A -- "k8s_namespace now references resource attribute" --> B
  B -- "only kubernetes_secret.k8s_secret inherits dependency" --> C["data.google_secret_manager_secret_version resolves at plan time"]
  C -- "no spurious diffs" --> D["kubernetes_secret payloads & google_sql_user.password stable"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Replace module-level depends_on with resource attribute reference</code></dd></summary>
<hr>

main.tf

<ul><li>Removed <code>depends_on = [kubernetes_namespace.gitlab_namespace]</code> from five <br><code>gitlab_*_pass</code> module blocks<br> <li> Changed <code>k8s_namespace</code> from <code>var.gitlab_namespace</code> to <br><code>kubernetes_namespace.gitlab_namespace.metadata[0].name</code> in all five <br>module calls<br> <li> Minor formatting cleanup of <code>count</code> attribute alignment in several <br>module blocks</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/125/files#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbb">+9/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CHANGELOG.md</strong><dd><code>Document secret manager plan-time read fix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG.md

<ul><li>Added a "Fixed" entry under "Unreleased" describing the secret manager <br>data source deferral fix</ul>


</details>


  </td>
  <td><a href="https://github.com/sparkfabrik/terraform-sparkfabrik-gke-gitlab/pull/125/files#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4ed">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___



---

> Assisted-by: pr-agent/z-ai/glm-5.2